### PR TITLE
Build config files first in default gulp task

### DIFF
--- a/ESSArch_TA/frontend/static/frontend/gulpfile.js
+++ b/ESSArch_TA/frontend/static/frontend/gulpfile.js
@@ -267,9 +267,7 @@ var permissionConfig = function() {
     .pipe(gulp.dest('./scripts/configs'));
 };
 
-gulp.task('default', ['core_templates', 'core_scripts', 'core_tests',], function() {
-    configConstants();
-    permissionConfig();
+gulp.task('default', ['config', 'permission_config', 'core_templates', 'core_scripts', 'core_tests',], function() {
     compileSass();
     copyIcons();
     copyImages()
@@ -288,6 +286,7 @@ gulp.task('scripts', buildScripts);
 gulp.task('vendors', buildVendors);
 gulp.task('sass', compileSass);
 gulp.task('config', configConstants);
+gulp.task('permission_config', permissionConfig);
 
 gulp.task('watch', function(){
     gulp.watch(coreHtmlFiles, ['core_templates']);


### PR DESCRIPTION
Currently when cloning the repo it is required to run gulp twice for building a correct script. This is because the config files aren't created before the scripts are generated. This fixes that by moving the creation of the config files to the start of the task.