### PR TITLE
Fix logging of exception in Python 3

### DIFF
--- a/ESSArch_TA/ip/views.py
+++ b/ESSArch_TA/ip/views.py
@@ -80,7 +80,7 @@ class InformationPackageReceptionViewSet(viewsets.ViewSet, PaginatedViewMixin):
         try:
             ip = parse_submit_description(xmlfile, srcdir)
         except (etree.LxmlError, ValueError) as e:
-            self.logger.exception(u'Failed to parse %s'.format(xmlfile))
+            self.logger.exception(u'Failed to parse {}'.format(xmlfile))
             raise
 
         ip['state'] = 'At reception'

--- a/ESSArch_TA/ip/views.py
+++ b/ESSArch_TA/ip/views.py
@@ -80,7 +80,7 @@ class InformationPackageReceptionViewSet(viewsets.ViewSet, PaginatedViewMixin):
         try:
             ip = parse_submit_description(xmlfile, srcdir)
         except (etree.LxmlError, ValueError) as e:
-            self.logger.warn('Failed to parse %s: %s' % (xmlfile, e.message))
+            self.logger.exception(u'Failed to parse %s'.format(xmlfile))
             raise
 
         ip['state'] = 'At reception'


### PR DESCRIPTION
`ValueError` in Python 3 no longer has the `message` attribute. Using `logger.exception` instead of `logger.warning` still lets us include the message and it works in Python 2 and 3