### PR TITLE
Remove Python 2/3 compatibility imports

### DIFF
--- a/ESSArch_TA/config/__init__.py
+++ b/ESSArch_TA/config/__init__.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import, unicode_literals
-
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app  # noqa

--- a/ESSArch_TA/config/celery.py
+++ b/ESSArch_TA/config/celery.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import
-
 import os
 
 from celery import Celery

--- a/ESSArch_TA/preingest/tasks.py
+++ b/ESSArch_TA/preingest/tasks.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import
-
 import os
 import shutil
 

--- a/ESSArch_TA/preingest/tests/test_views.py
+++ b/ESSArch_TA/preingest/tests/test_views.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 from django.contrib.auth.models import Permission, User
 from django.test import TestCase
 from django.urls import reverse


### PR DESCRIPTION
We have upgraded to Python 3, we no longer require tools that makes the migration easier