### PR TITLE
Add Elastic-stack support for visualization of logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ SIP receiving tools for archives.
 
 Instructions for preparing for, installing and setting up ETA (and ESSArch Core) can be found at http://doc.essarch.org/
 
+# Running services in docker
+
+To run the DB, redis, rabbitmq and Elastic-services in docker follow the below instructions:
+
+Navigate to the folder where docker-compose.yml file is located:
+
+    cd docker/eta
+
+To start all services run:
+
+    docker-compose up -d
+
+Then navigate to http://localhost:5602 to open up Kibana.
+
 # Documentation 
 
 Source for the documentation can be found in the `docs` folder

--- a/docker/eta/.env
+++ b/docker/eta/.env
@@ -1,0 +1,1 @@
+ELK_VERSION=6.5.4

--- a/docker/eta/docker-compose.yml
+++ b/docker/eta/docker-compose.yml
@@ -1,0 +1,74 @@
+version: '3'
+
+services:
+    db:
+        image: "mariadb:10.2.16"
+        ports:
+            - 3002:3306
+        environment:
+            MYSQL_DATABASE: eta
+            MYSQL_USER: arkiv
+            MYSQL_PASSWORD: password
+            MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    rabbitmq:
+        image: "rabbitmq:latest"
+        ports:
+            - 15002:5672
+        environment:
+            - RABBITMQ_DEFAULT_USER=rabbitmq
+            - RABBITMQ_DEFAULT_PASS=rabbitmq
+    redis:
+        image: "redis:latest"
+        ports:
+            - 6002:6379
+
+    elasticsearch:
+        build:
+            context: elasticsearch/
+            args:
+                ELK_VERSION: $ELK_VERSION
+        volumes:
+            - ./elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+        ports:
+            - "9202:9200"
+            - "9302:9300"
+        environment:
+            ES_JAVA_OPTS: "-Xmx256m -Xms256m"
+        networks:
+            - elk
+
+    logstash:
+        build:
+            context: logstash/
+            args:
+                ELK_VERSION: $ELK_VERSION
+        volumes:
+            - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
+            - ./logstash/pipeline:/usr/share/logstash/pipeline:ro
+        ports:
+            - "5002:5000"
+            - "9602:9600"
+        environment:
+            LS_JAVA_OPTS: "-Xmx256m -Xms256m"
+        networks:
+            - elk
+        depends_on:
+            - elasticsearch
+
+    kibana:
+        build:
+            context: kibana/
+            args:
+                ELK_VERSION: $ELK_VERSION
+        volumes:
+            - ./kibana/config/:/usr/share/kibana/config:ro
+        ports:
+            - "5602:5601"
+        networks:
+            - elk
+        depends_on:
+            - elasticsearch
+
+networks:
+    elk:
+        driver: bridge

--- a/docker/eta/elasticsearch/Dockerfile
+++ b/docker/eta/elasticsearch/Dockerfile
@@ -1,0 +1,8 @@
+ARG ELK_VERSION
+
+# https://github.com/elastic/elasticsearch-docker
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
+
+# Add your elasticsearch plugins setup here
+
+RUN elasticsearch-plugin install --batch ingest-attachment

--- a/docker/eta/elasticsearch/config/elasticsearch.yml
+++ b/docker/eta/elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,16 @@
+---
+## Default Elasticsearch configuration from elasticsearch-docker.
+## from https://github.com/elastic/elasticsearch-docker/blob/master/build/elasticsearch/elasticsearch.yml
+#
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1
+
+## Use single node discovery in order to disable production mode and avoid bootstrap checks
+## see https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
+#
+discovery.type: single-node

--- a/docker/eta/kibana/Dockerfile
+++ b/docker/eta/kibana/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELK_VERSION
+
+# https://github.com/elastic/kibana-docker
+FROM docker.elastic.co/kibana/kibana:${ELK_VERSION}
+
+# Add your kibana plugins setup here
+# Example: RUN kibana-plugin install <name|url>

--- a/docker/eta/kibana/config/kibana.yml
+++ b/docker/eta/kibana/config/kibana.yml
@@ -1,0 +1,7 @@
+---
+## Default Kibana configuration from kibana-docker.
+## from https://github.com/elastic/kibana-docker/blob/master/build/kibana/config/kibana.yml
+#
+server.name: kibana
+server.host: "0"
+elasticsearch.url: http://elasticsearch:9200

--- a/docker/eta/logstash/Dockerfile
+++ b/docker/eta/logstash/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELK_VERSION
+
+# https://github.com/elastic/logstash-docker
+FROM docker.elastic.co/logstash/logstash:${ELK_VERSION}
+
+# Add your logstash plugins setup here
+# Example: RUN logstash-plugin install logstash-filter-json

--- a/docker/eta/logstash/config/logstash.yml
+++ b/docker/eta/logstash/config/logstash.yml
@@ -1,0 +1,6 @@
+---
+## Default Logstash configuration from logstash-docker.
+## from https://github.com/elastic/logstash-docker/blob/master/build/logstash/config/logstash-oss.yml
+#
+http.host: "0.0.0.0"
+path.config: /usr/share/logstash/pipeline

--- a/docker/eta/logstash/pipeline/logstash.conf
+++ b/docker/eta/logstash/pipeline/logstash.conf
@@ -1,0 +1,20 @@
+input {
+	tcp {
+		port => 5000
+		codec => json
+	}
+}
+
+## Add your filters / logstash plugins configuration here
+filter {
+    json {
+        source => "[message][raw]"
+    }
+}
+
+
+output {
+	elasticsearch {
+		hosts => "elasticsearch:9200"
+	}
+}


### PR DESCRIPTION
- If LOGGING parameter/dict is defined in local-eta-settings.py, it will override the default LOGGING settings.
To log to logstash, add a configuration like this to LOGGING:
```
'handlers': {
    'logstash': {
        'level': 'INFO',
        'class': 'logstash.TCPLogstashHandler',
        'host': 'localhost',
        'port': 5002,
        'version': 1,
        'message_type': 'django',
        'fqdn': False,
        'tags': ['ETA'],
    },
},
'loggers': {
    'essarch': {
        'handlers': ['core', 'file_etp', 'logstash'],
        'level': 'DEBUG',
    },
    'essarch.auth' : {
        'level': 'DEBUG',
        'handlers': ['log_file_auth', 'logstash'],
        'propagate': False,
    }
}
```