### PR TITLE
Fix Django deprecations

### DIFF
--- a/ESSArch_TA/config/settings.py
+++ b/ESSArch_TA/config/settings.py
@@ -169,7 +169,7 @@ ASGI_APPLICATION = 'ESSArch_Core.routing.application'
 
 SITE_ID = 1
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/ESSArch_TA/config/urls.py
+++ b/ESSArch_TA/config/urls.py
@@ -123,11 +123,11 @@ urlpatterns = [
     url(r'^api/sysinfo/', SysInfoView.as_view()),
     url(r'^api/me/$', MeView.as_view(), name='me'),
     url(r'^api/', include(router.urls)),
-    url(r'^accounts/changepassword', auth_views.password_change, {'post_change_redirect': '/'}),
+    url(r'^accounts/changepassword', auth_views.PasswordChangeView.as_view(), {'post_change_redirect': '/'}),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^docs/', include('ESSArch_Core.docs.urls')),
     url(r'^template/', include('ESSArch_Core.essxml.ProfileMaker.urls')),
-    url(r'^accounts/login/$', auth_views.login),
+    url(r'^accounts/login/$', auth_views.LoginView.as_view()),
     url(r'^rest-auth/', include('ESSArch_Core.auth.urls')),
     url(r'^rest-auth/registration/', include('rest_auth.registration.urls')),
 ]


### PR DESCRIPTION
[Django 1.10](https://docs.djangoproject.com/en/1.11/releases/1.10/#new-style-middleware): the `MIDDLEWARE_CLASSES` setting has been replaced by `MIDDLEWARE`

[Django 1.11](https://docs.djangoproject.com/en/1.11/releases/1.11/#django-contrib-auth): `django.contrib.auth.views.password_change` and `django.contrib.auth.views.login` has been replaced by `django.contrib.auth.views.PasswordChangeView` and `django.contrib.auth.views.LoginView`